### PR TITLE
fix: fix NPE (videoId)

### DIFF
--- a/app/(root)/index.tsx
+++ b/app/(root)/index.tsx
@@ -76,7 +76,7 @@ const Queue = () => {
     <>
       <View style={{ flex: 1, paddingBottom }}>
         <FlashList
-          data={queue.items}
+          data={queue.items.filter((it) => item.playlistPanelVideoRenderer.videoId)}
           renderItem={({ item }) => (
             <QueueListItem song={item.playlistPanelVideoRenderer} />
           )}


### PR DESCRIPTION
- `queue-info` may return a UI panel unrelated to the video.