### PR TITLE
Improve remote connection support and legacy desktop auth flow

### DIFF
--- a/__tests__/utils/auth.test.ts
+++ b/__tests__/utils/auth.test.ts
@@ -1,0 +1,11 @@
+import { getAuthorizationHeader } from '@/utils/auth';
+
+describe('getAuthorizationHeader', () => {
+  it('adds the bearer prefix to raw tokens', () => {
+    expect(getAuthorizationHeader('abc123')).toBe('Bearer abc123');
+  });
+
+  it('preserves tokens that already include the bearer prefix', () => {
+    expect(getAuthorizationHeader('Bearer abc123')).toBe('Bearer abc123');
+  });
+});

--- a/__tests__/utils/connectionUrl.test.ts
+++ b/__tests__/utils/connectionUrl.test.ts
@@ -1,0 +1,66 @@
+import {
+  getConnectionOrigin,
+  getConnectionProtocol,
+  isLocalConnectionHost,
+} from '@/utils/connectionUrl';
+
+describe('connectionUrl helpers', () => {
+  describe('isLocalConnectionHost', () => {
+    it('treats localhost-like targets as local', () => {
+      expect(isLocalConnectionHost('localhost')).toBe(true);
+      expect(isLocalConnectionHost('musicbox')).toBe(true);
+      expect(isLocalConnectionHost('speaker.local')).toBe(true);
+      expect(isLocalConnectionHost('192.168.1.25')).toBe(true);
+    });
+
+    it('treats public hostnames as remote', () => {
+      expect(isLocalConnectionHost('example.com')).toBe(false);
+      expect(isLocalConnectionHost('remote.example.net')).toBe(false);
+      expect(isLocalConnectionHost('8.8.8.8')).toBe(false);
+    });
+  });
+
+  describe('getConnectionProtocol', () => {
+    it('uses insecure protocols for local targets', () => {
+      expect(getConnectionProtocol('musicbox')).toBe('http');
+      expect(getConnectionProtocol('musicbox', 'ws')).toBe('ws');
+    });
+
+    it('uses secure protocols for public targets', () => {
+      expect(getConnectionProtocol('example.com')).toBe('https');
+      expect(getConnectionProtocol('example.com', 'ws')).toBe('wss');
+    });
+  });
+
+  describe('getConnectionOrigin', () => {
+    it('keeps the default local port for local targets', () => {
+      expect(getConnectionOrigin({ host: 'localhost', port: '' })).toBe(
+        'http://localhost:26538'
+      );
+    });
+
+    it('omits default-like ports for remote targets', () => {
+      expect(getConnectionOrigin({ host: 'example.com', port: '' })).toBe(
+        'https://example.com'
+      );
+      expect(getConnectionOrigin({ host: 'example.com', port: '443' })).toBe(
+        'https://example.com'
+      );
+      expect(getConnectionOrigin({ host: 'example.com', port: '26538' })).toBe(
+        'https://example.com'
+      );
+    });
+
+    it('keeps custom ports for remote targets', () => {
+      expect(getConnectionOrigin({ host: 'example.com', port: '8443' })).toBe(
+        'https://example.com:8443'
+      );
+    });
+
+    it('falls back to 0.0.0.0 when the host is blank', () => {
+      expect(getConnectionOrigin({ host: '   ', port: '' })).toBe(
+        'http://0.0.0.0:26538'
+      );
+    });
+  });
+});

--- a/__tests__/utils/seek.test.ts
+++ b/__tests__/utils/seek.test.ts
@@ -1,0 +1,64 @@
+import {
+  isWithinSeekTolerance,
+  shouldIgnoreSeekPositionUpdate,
+} from '@/utils/seek';
+
+describe('seek helpers', () => {
+  describe('isWithinSeekTolerance', () => {
+    it('treats values within one second as equivalent', () => {
+      expect(isWithinSeekTolerance(10, 10)).toBe(true);
+      expect(isWithinSeekTolerance(10, 11)).toBe(true);
+      expect(isWithinSeekTolerance(10, 9)).toBe(true);
+    });
+
+    it('treats larger jumps as meaningfully different', () => {
+      expect(isWithinSeekTolerance(10, 12)).toBe(false);
+    });
+  });
+
+  describe('shouldIgnoreSeekPositionUpdate', () => {
+    it('ignores stale realtime positions while a local seek is still in flight', () => {
+      expect(
+        shouldIgnoreSeekPositionUpdate({
+          position: 15,
+          pendingSeekSeconds: 30,
+          seekInFlightUntil: 5_000,
+          now: 4_000,
+        })
+      ).toBe(true);
+    });
+
+    it('accepts positions once the server catches up', () => {
+      expect(
+        shouldIgnoreSeekPositionUpdate({
+          position: 29,
+          pendingSeekSeconds: 30,
+          seekInFlightUntil: 5_000,
+          now: 4_000,
+        })
+      ).toBe(false);
+    });
+
+    it('accepts positions after the grace window expires', () => {
+      expect(
+        shouldIgnoreSeekPositionUpdate({
+          position: 15,
+          pendingSeekSeconds: 30,
+          seekInFlightUntil: 5_000,
+          now: 5_000,
+        })
+      ).toBe(false);
+    });
+
+    it('accepts positions when there is no pending local seek', () => {
+      expect(
+        shouldIgnoreSeekPositionUpdate({
+          position: 15,
+          pendingSeekSeconds: null,
+          seekInFlightUntil: 5_000,
+          now: 4_000,
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/app/(root)/index.tsx
+++ b/app/(root)/index.tsx
@@ -43,7 +43,7 @@ const Queue = () => {
   const isWebsocketLoading = useAtomValue(isWebsocketConnectingAtom);
   const isWebsocketError = useAtomValue(isWebsocketErrorAtom);
 
-  const isLoading = isLoadingQueue || isWebsocketLoading;
+  const isLoading = isLoadingQueue || (!isFetched && isWebsocketLoading);
 
   const { bottom: bottomInset } = useSafeAreaInsets();
 
@@ -115,13 +115,15 @@ const Queue = () => {
       />
     );
 
-  if (isWebsocketError)
-    return <ConnectionError type='noConnection' style={{ paddingBottom }} />;
-
   if (isLoading || !isFetched) return <LoadingView />;
 
-  if (isWebsocketError && isErrorQueue)
-    return <ConnectionError type='serverError' style={{ paddingBottom }} />;
+  if (isErrorQueue)
+    return (
+      <ConnectionError
+        type={isWebsocketError ? 'serverError' : 'noConnection'}
+        style={{ paddingBottom }}
+      />
+    );
 
   if (!queue || !queue.items?.length)
     return (

--- a/components/Player/PlayerSeekBar.tsx
+++ b/components/Player/PlayerSeekBar.tsx
@@ -12,7 +12,7 @@ import {
 import { useNowPlayingElapsedSeconds } from '@/hooks';
 import { SongInfoSchema } from '@/schemas';
 import { seek } from '@/services';
-import { formatSecondsToDuration } from '@/utils';
+import { formatSecondsToDuration, isWithinSeekTolerance } from '@/utils';
 
 import Slider from '../Slider';
 
@@ -47,7 +47,7 @@ const PlayerSeekBar = ({ songInfo }: PlayerSeekBarProps) => {
     // Web jitter reduction fix: Do not update if new value is just within
     // threshold (1 second) from current server elapsed seconds
     if (Platform.OS === 'web') {
-      if (Math.abs(elapsedSeconds - seekValue) <= 1) return;
+      if (isWithinSeekTolerance(elapsedSeconds, seekValue)) return;
     }
 
     setSeekBarValue(value);

--- a/components/Player/PlayerSeekBar.tsx
+++ b/components/Player/PlayerSeekBar.tsx
@@ -1,7 +1,14 @@
+import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { Platform, StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
 
+import {
+  pendingSeekSecondsAtom,
+  queryClient,
+  seekInFlightUntilAtom,
+  store,
+} from '@/configs';
 import { useNowPlayingElapsedSeconds } from '@/hooks';
 import { SongInfoSchema } from '@/schemas';
 import { seek } from '@/services';
@@ -24,11 +31,15 @@ const styles = StyleSheet.create({
   },
 });
 
+const SEEK_GRACE_PERIOD_MS = 2500;
+
 const PlayerSeekBar = ({ songInfo }: PlayerSeekBarProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'player' });
 
   const { elapsedSeconds, seekBarValue, setSeekBarValue } =
     useNowPlayingElapsedSeconds();
+  const [, setSeekInFlightUntil] = useAtom(seekInFlightUntilAtom);
+  const [, setPendingSeekSeconds] = useAtom(pendingSeekSecondsAtom);
 
   const seekSeconds = async (value: number) => {
     const seekValue = Math.round(value * songInfo.songDuration);
@@ -40,6 +51,15 @@ const PlayerSeekBar = ({ songInfo }: PlayerSeekBarProps) => {
     }
 
     setSeekBarValue(value);
+    setPendingSeekSeconds(seekValue);
+    const seekExpiry = Date.now() + SEEK_GRACE_PERIOD_MS;
+    setSeekInFlightUntil(seekExpiry);
+    queryClient.setQueryData(['nowPlayingElapsedSeconds'], () => seekValue);
+    setTimeout(() => {
+      if (store.get(seekInFlightUntilAtom) !== seekExpiry) return;
+      store.set(seekInFlightUntilAtom, 0);
+      store.set(pendingSeekSecondsAtom, null);
+    }, SEEK_GRACE_PERIOD_MS);
     await seek(seekValue);
   };
 

--- a/configs/api.ts
+++ b/configs/api.ts
@@ -3,12 +3,23 @@ import axios from 'axios';
 import { DEFAULT_SETTINGS } from '../constants/defaultSettings';
 import { getConnectionOrigin } from '../utils';
 
-import { accessTokenAtom, settingAtomFamily, store } from './storage';
+import {
+  accessTokenAtom,
+  getClientId,
+  settingAtomFamily,
+  store,
+} from './storage';
 
 export const API_VERSION = 'v1';
+const REQUEST_TIMEOUT_MS = 5000;
+const AUTHENTICATION_TIMEOUT_MS = 35000;
 
 // explicitly set the timeout to 5s due to React Native not failing requests
-axios.defaults.timeout = 5000;
+axios.defaults.timeout = REQUEST_TIMEOUT_MS;
+const authClient = axios.create({
+  timeout: AUTHENTICATION_TIMEOUT_MS,
+});
+let authenticationPromise: Promise<string> | null = null;
 
 const getHost = () => {
   const ipAddress =
@@ -23,18 +34,34 @@ const getHost = () => {
 };
 
 const authenticate = async () => {
-  const host = getHost();
-  const { data } = await axios.post<{ accessToken: string }>(`${host}/auth/1`);
-  store.set(accessTokenAtom, data.accessToken);
-  return data.accessToken;
+  if (authenticationPromise) return authenticationPromise;
+
+  authenticationPromise = (async () => {
+    const host = getHost();
+    const clientId = getClientId();
+    const { data } = await authClient.post<{ accessToken: string }>(
+      `${host}/auth/${clientId}`
+    );
+    store.set(accessTokenAtom, data.accessToken);
+    return data.accessToken;
+  })();
+
+  try {
+    return await authenticationPromise;
+  } finally {
+    authenticationPromise = null;
+  }
 };
+
+const getAuthorizationHeader = (accessToken: string) =>
+  accessToken.startsWith('Bearer ') ? accessToken : `Bearer ${accessToken}`;
 
 axios.interceptors.request.use((config) => {
   const host = getHost();
   config.baseURL = `${host}/api/${API_VERSION}`;
   const accessToken = store.get(accessTokenAtom);
   if (accessToken) {
-    config.headers['Authorization'] = accessToken;
+    config.headers['Authorization'] = getAuthorizationHeader(accessToken);
   }
   return config;
 });
@@ -53,7 +80,8 @@ axios.interceptors.response.use(
       originalRequest._retry = true;
       try {
         const accessToken = await authenticate();
-        originalRequest.headers['Authorization'] = accessToken;
+        originalRequest.headers['Authorization'] =
+          getAuthorizationHeader(accessToken);
         return axios.request(originalRequest);
       } catch (error) {
         return Promise.reject(error);

--- a/configs/api.ts
+++ b/configs/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { DEFAULT_SETTINGS } from '../constants/defaultSettings';
-import { getConnectionOrigin } from '../utils';
+import { getAuthorizationHeader, getConnectionOrigin } from '../utils';
 
 import {
   accessTokenAtom,
@@ -52,9 +52,6 @@ const authenticate = async () => {
     authenticationPromise = null;
   }
 };
-
-const getAuthorizationHeader = (accessToken: string) =>
-  accessToken.startsWith('Bearer ') ? accessToken : `Bearer ${accessToken}`;
 
 axios.interceptors.request.use((config) => {
   const host = getHost();

--- a/configs/api.ts
+++ b/configs/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { DEFAULT_SETTINGS } from '../constants/defaultSettings';
+import { getConnectionOrigin } from '../utils';
 
 import { accessTokenAtom, settingAtomFamily, store } from './storage';
 
@@ -14,7 +15,11 @@ const getHost = () => {
     (store.get(settingAtomFamily('ipAddress')) as string) || '0.0.0.0';
   const port =
     (store.get(settingAtomFamily('port')) as string) || DEFAULT_SETTINGS.port;
-  return `http://${ipAddress}:${port}`;
+  return getConnectionOrigin({
+    host: ipAddress,
+    port,
+    protocolFamily: 'http',
+  });
 };
 
 const authenticate = async () => {

--- a/configs/storage.ts
+++ b/configs/storage.ts
@@ -84,6 +84,8 @@ export const sleepTimerActiveAtom = atom(false);
 // slider states (due to web slider jitteriness)
 export const seekBarValueAtom = atom(0); // 0 to 1
 export const volumeSliderValueAtom = atom(0); // 0 to 100
+export const seekInFlightUntilAtom = atom(0);
+export const pendingSeekSecondsAtom = atom<number | null>(null);
 
 // realtime updates
 export const isWebsocketConnectingAtom = atom(true);

--- a/configs/storage.ts
+++ b/configs/storage.ts
@@ -61,6 +61,21 @@ export const useSettingAtom = <K extends keyof SettingsSchema>(setting: K) =>
 
 // access token
 export const accessTokenAtom = atomWithMMKV('accessToken', '');
+const CLIENT_ID_STORAGE_KEY = 'clientId';
+
+const createClientId = () =>
+  `yt-music-remote-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+
+export const getClientId = () => {
+  const existingClientId = storage.getString(CLIENT_ID_STORAGE_KEY);
+  if (existingClientId) return existingClientId;
+
+  const clientId = createClientId();
+  storage.set(CLIENT_ID_STORAGE_KEY, clientId);
+  return clientId;
+};
 
 // sleep timer
 export const sleepTimerAtom = atom(0); // in seconds

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -16,6 +16,20 @@ export const LANGUAGES = ['en', 'ja'] as const;
 // Settings
 export const MIN_CONNECTION_PROFILES = 5;
 
+const IPV4_SEGMENT_PATTERN = '(25[0-5]|2[0-4]\\d|1?\\d?\\d)';
+const IPV4_ADDRESS_REGEX = new RegExp(
+  `^(?:${IPV4_SEGMENT_PATTERN}\\.){3}${IPV4_SEGMENT_PATTERN}$`
+);
+const HOSTNAME_LABEL_REGEX = /^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)$/;
+
+const isValidHostname = (value: string) => {
+  if (!value || value.length > 253) return false;
+
+  return value
+    .split('.')
+    .every((label) => !!label && HOSTNAME_LABEL_REGEX.test(label));
+};
+
 export const SETTINGS_KEYS = [
   // connection
   'ipAddress',
@@ -50,10 +64,7 @@ export const TEXT_SETTINGS: Record<
     category: 'connection',
     required: true,
     validation: (value) => {
-      if (
-        !/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(value) &&
-        value !== 'localhost'
-      )
+      if (!IPV4_ADDRESS_REGEX.test(value) && !isValidHostname(value))
         return 'settings.connection.invalidIpAddress';
       return null;
     },
@@ -61,8 +72,9 @@ export const TEXT_SETTINGS: Record<
   },
   port: {
     category: 'connection',
-    required: true,
+    required: false,
     validation: (value) => {
+      if (!value) return null;
       if (isNaN(+value)) return 'settings.connection.invalidPort';
       if (+value < 0 || +value > 65535)
         return 'settings.connection.invalidPortRange';

--- a/hooks/useConnectionString.ts
+++ b/hooks/useConnectionString.ts
@@ -8,6 +8,7 @@ import {
 } from '@/configs';
 import { DEFAULT_SETTINGS, MIN_CONNECTION_PROFILES } from '@/constants';
 import { SettingsSchema } from '@/schemas';
+import { getConnectionOrigin } from '@/utils';
 
 const DEFAULT_CONNECTION_PROFILE: SettingsSchema['connectionProfiles'][0] = {
   ipAddress: '',
@@ -67,5 +68,9 @@ export const useConnectionString = (protocol: 'http' | 'ws' = 'http') => {
     }
   }, [connectionProfile, setConnectionProfiles, setConnectionProfile]);
 
-  return `${protocol}://${ipAddress || '0.0.0.0'}:${port || DEFAULT_SETTINGS.port}/api/${API_VERSION}`;
+  return `${getConnectionOrigin({
+    host: ipAddress || '0.0.0.0',
+    port: port || DEFAULT_SETTINGS.port,
+    protocolFamily: protocol,
+  })}/api/${API_VERSION}`;
 };

--- a/hooks/useNowPlaying.ts
+++ b/hooks/useNowPlaying.ts
@@ -3,7 +3,11 @@ import { useCallback, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 
-import { seekBarValueAtom, useSettingAtom } from '@/configs';
+import {
+  pendingSeekSecondsAtom,
+  seekBarValueAtom,
+  useSettingAtom,
+} from '@/configs';
 import { SongInfoSchema } from '@/schemas';
 
 /**
@@ -25,6 +29,7 @@ export const useNowPlayingElapsedSeconds = () => {
   }, [queryClient]);
 
   const [seekBarValue, setSeekBarValue] = useAtom(seekBarValueAtom);
+  const [pendingSeekSeconds] = useAtom(pendingSeekSecondsAtom);
 
   // init seek bar value
   useEffect(() => {
@@ -40,7 +45,8 @@ export const useNowPlayingElapsedSeconds = () => {
   });
 
   return {
-    elapsedSeconds,
+    elapsedSeconds:
+      pendingSeekSeconds !== null ? pendingSeekSeconds : elapsedSeconds,
     seekBarValue,
     setSeekBarValue,
   };

--- a/hooks/useNowPlaying.ts
+++ b/hooks/useNowPlaying.ts
@@ -54,9 +54,8 @@ export const useNowPlayingElapsedSeconds = () => {
 export const useNowPlaying = () => {
   const queryClient = useQueryClient();
   const [ipAddress] = useSettingAtom('ipAddress');
-  const [port] = useSettingAtom('port');
 
-  const enabled = !!ipAddress && !!port;
+  const enabled = !!ipAddress;
 
   const useQueryResult = useQuery({
     queryKey: ['nowPlaying'],

--- a/hooks/useQueue.ts
+++ b/hooks/useQueue.ts
@@ -12,9 +12,8 @@ import { getQueue } from '@/services';
  */
 export const useQueue = () => {
   const [ipAddress] = useSettingAtom('ipAddress');
-  const [port] = useSettingAtom('port');
 
-  const enabled = !!ipAddress && !!port;
+  const enabled = !!ipAddress;
 
   const useQueryResult = useQuery({
     queryKey: ['queue'],

--- a/hooks/useRealtimeUpdates.ts
+++ b/hooks/useRealtimeUpdates.ts
@@ -8,8 +8,10 @@ import {
   accessTokenAtom,
   isWebsocketConnectingAtom,
   isWebsocketErrorAtom,
+  pendingSeekSecondsAtom,
   queryClient,
   seekBarValueAtom,
+  seekInFlightUntilAtom,
   store,
   useSettingAtom,
   volumeSliderValueAtom,
@@ -42,8 +44,17 @@ export const useRealtimeUpdates = (enabled: boolean) => {
 
   const handleMessage = useCallback(async (messageData: string) => {
     const message: WebsocketDataSchema = JSON.parse(messageData);
+    const seekInFlightUntil = store.get(seekInFlightUntilAtom);
+    const pendingSeekSeconds = store.get(pendingSeekSecondsAtom);
+    const isSeekInFlight = seekInFlightUntil > Date.now();
+    const shouldIgnoreSeekPositionUpdate = (position: number) =>
+      isSeekInFlight &&
+      pendingSeekSeconds !== null &&
+      Math.abs(position - pendingSeekSeconds) > 1;
+
     switch (message.type) {
       case WebsocketDataTypes.PlayerInfo: {
+        if (shouldIgnoreSeekPositionUpdate(message.position)) break;
         queryClient.setQueryData(['nowPlaying'], () => message.song || null);
         queryClient.setQueryData(
           ['nowPlayingElapsedSeconds'],
@@ -60,6 +71,8 @@ export const useRealtimeUpdates = (enabled: boolean) => {
         break;
       }
       case WebsocketDataTypes.VideoChanged: {
+        store.set(seekInFlightUntilAtom, 0);
+        store.set(pendingSeekSecondsAtom, null);
         queryClient.setQueryData(['nowPlaying'], () => message.song);
         queryClient.setQueryData(
           ['nowPlayingElapsedSeconds'],
@@ -81,6 +94,9 @@ export const useRealtimeUpdates = (enabled: boolean) => {
         break;
       }
       case WebsocketDataTypes.PlayerStateChanged: {
+        if (shouldIgnoreSeekPositionUpdate(message.position)) break;
+        store.set(seekInFlightUntilAtom, 0);
+        store.set(pendingSeekSecondsAtom, null);
         queryClient.setQueryData(['isPlaying'], () => message.isPlaying);
         queryClient.setQueryData(
           ['nowPlayingElapsedSeconds'],
@@ -90,6 +106,9 @@ export const useRealtimeUpdates = (enabled: boolean) => {
         break;
       }
       case WebsocketDataTypes.PositionChanged: {
+        if (shouldIgnoreSeekPositionUpdate(message.position)) break;
+        store.set(seekInFlightUntilAtom, 0);
+        store.set(pendingSeekSecondsAtom, null);
         queryClient.setQueryData(
           ['nowPlayingElapsedSeconds'],
           () => message.position

--- a/hooks/useRealtimeUpdates.ts
+++ b/hooks/useRealtimeUpdates.ts
@@ -1,8 +1,11 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { useAtomValue } from 'jotai';
+import { Platform } from 'react-native';
 import useWebSocket, { ReadyState } from 'react-use-websocket-lite';
 
 import {
+  accessTokenAtom,
   isWebsocketConnectingAtom,
   isWebsocketErrorAtom,
   queryClient,
@@ -20,14 +23,96 @@ import { useConnectionString } from './useConnectionString';
 const WEBSOCKET_RECONNECT_INTERVAL_MS = 5000;
 const QUEUE_REFETCH_DELAY_MS = 500;
 
+const getAuthorizationHeader = (accessToken: string) =>
+  accessToken.startsWith('Bearer ') ? accessToken : `Bearer ${accessToken}`;
+
 /**
  * Re-implementation of useQuery hooks from original polled REST API GET
  * requests to use WebSocket (real-time updates) instead.
  */
 export const useRealtimeUpdates = (enabled: boolean) => {
   const [ipAddress] = useSettingAtom('ipAddress');
+  const accessToken = useAtomValue(accessTokenAtom);
   const connectionString = useConnectionString('ws');
   const url = `${connectionString}/ws`;
+  const shouldConnect = enabled && !!ipAddress;
+  const [nativeReadyState, setNativeReadyState] = useState<ReadyState>(
+    ReadyState.UNINSTANTIATED
+  );
+
+  const handleMessage = useCallback(async (messageData: string) => {
+    const message: WebsocketDataSchema = JSON.parse(messageData);
+    switch (message.type) {
+      case WebsocketDataTypes.PlayerInfo: {
+        queryClient.setQueryData(['nowPlaying'], () => message.song || null);
+        queryClient.setQueryData(
+          ['nowPlayingElapsedSeconds'],
+          () => message.position
+        );
+        queryClient.setQueryData(['isPlaying'], () => message.isPlaying);
+        queryClient.setQueryData(['isMuted'], () => message.muted);
+        queryClient.setQueryData(['volume'], () => message.volume);
+        queryClient.setQueryData(['repeatMode'], () => message.repeat);
+        queryClient.setQueryData(['isShuffle'], () => message.shuffle);
+        store.set(seekBarValueAtom, getSeekBarValue());
+        store.set(volumeSliderValueAtom, message.volume);
+
+        break;
+      }
+      case WebsocketDataTypes.VideoChanged: {
+        queryClient.setQueryData(['nowPlaying'], () => message.song);
+        queryClient.setQueryData(
+          ['nowPlayingElapsedSeconds'],
+          () => message.position
+        );
+        queryClient.setQueryData(['isPlaying'], () => !message.song?.isPaused);
+        store.set(seekBarValueAtom, getSeekBarValue());
+
+        const data = await getQueue();
+
+        if (data?.items.length) {
+          queryClient.setQueryData(['queue'], () => data);
+        } else {
+          setTimeout(() => {
+            queryClient.refetchQueries({ queryKey: ['queue'] });
+          }, QUEUE_REFETCH_DELAY_MS);
+        }
+
+        break;
+      }
+      case WebsocketDataTypes.PlayerStateChanged: {
+        queryClient.setQueryData(['isPlaying'], () => message.isPlaying);
+        queryClient.setQueryData(
+          ['nowPlayingElapsedSeconds'],
+          () => message.position
+        );
+        store.set(seekBarValueAtom, getSeekBarValue());
+        break;
+      }
+      case WebsocketDataTypes.PositionChanged: {
+        queryClient.setQueryData(
+          ['nowPlayingElapsedSeconds'],
+          () => message.position
+        );
+        store.set(seekBarValueAtom, getSeekBarValue());
+        break;
+      }
+      case WebsocketDataTypes.VolumeChanged: {
+        queryClient.setQueryData(['volume'], () => message.volume);
+        queryClient.setQueryData(['isMuted'], () => message.muted);
+        store.set(volumeSliderValueAtom, message.volume);
+        break;
+      }
+      case WebsocketDataTypes.RepeatChanged: {
+        queryClient.setQueryData(['repeatMode'], () => message.repeat);
+        break;
+      }
+      case WebsocketDataTypes.ShuffleChanged: {
+        queryClient.setQueryData(['isShuffle'], () => message.shuffle);
+        break;
+      }
+    }
+  }, []);
 
   // clear query cache on url change
   useEffect(() => {
@@ -36,10 +121,8 @@ export const useRealtimeUpdates = (enabled: boolean) => {
 
   const ws = useWebSocket({
     url,
-    connect: enabled && !!ipAddress,
-    onClose: () => {
-      queryClient.clear();
-    },
+    connect: Platform.OS === 'web' && shouldConnect,
+    onClose: () => {},
     onError: (e: any) => {
       if (e?.message === 'Software caused connection abort') {
         // due to app going to background on mobile devices
@@ -47,99 +130,75 @@ export const useRealtimeUpdates = (enabled: boolean) => {
         queryClient.refetchQueries({ queryKey: ['queue'] });
       } else {
         store.set(isWebsocketErrorAtom, true);
-        queryClient.clear();
       }
     },
-    onMessage: async (event) => {
-      const message: WebsocketDataSchema = JSON.parse(event.data);
-      switch (message.type) {
-        case WebsocketDataTypes.PlayerInfo: {
-          queryClient.setQueryData(['nowPlaying'], () => message.song || null);
-          queryClient.setQueryData(
-            ['nowPlayingElapsedSeconds'],
-            () => message.position
-          );
-          queryClient.setQueryData(['isPlaying'], () => message.isPlaying);
-          queryClient.setQueryData(['isMuted'], () => message.muted);
-          queryClient.setQueryData(['volume'], () => message.volume);
-          queryClient.setQueryData(['repeatMode'], () => message.repeat);
-          queryClient.setQueryData(['isShuffle'], () => message.shuffle);
-          store.set(seekBarValueAtom, getSeekBarValue());
-          store.set(volumeSliderValueAtom, message.volume);
-
-          break;
-        }
-        case WebsocketDataTypes.VideoChanged: {
-          queryClient.setQueryData(['nowPlaying'], () => message.song);
-          queryClient.setQueryData(
-            ['nowPlayingElapsedSeconds'],
-            () => message.position
-          );
-          queryClient.setQueryData(
-            ['isPlaying'],
-            () => !message.song?.isPaused
-          );
-          store.set(seekBarValueAtom, getSeekBarValue());
-
-          // There are edge cases where there are race condition issues between
-          // the new "now playing" song and queue. To mitigate this, refetch the
-          // queue when the now playing song exits and the queue is empty (after
-          // a short delay).
-          //
-          // Replicable via:
-          // - Playing a "video" (not a song) from "Listen again" section
-          // - Coming from a disconnected state then reconnecting
-          const data = await getQueue();
-
-          if (data?.items.length) {
-            queryClient.setQueryData(['queue'], () => data);
-          } else {
-            setTimeout(() => {
-              queryClient.refetchQueries({ queryKey: ['queue'] });
-            }, QUEUE_REFETCH_DELAY_MS);
-          }
-
-          break;
-        }
-        case WebsocketDataTypes.PlayerStateChanged: {
-          queryClient.setQueryData(['isPlaying'], () => message.isPlaying);
-          queryClient.setQueryData(
-            ['nowPlayingElapsedSeconds'],
-            () => message.position
-          );
-          store.set(seekBarValueAtom, getSeekBarValue());
-          break;
-        }
-        case WebsocketDataTypes.PositionChanged: {
-          queryClient.setQueryData(
-            ['nowPlayingElapsedSeconds'],
-            () => message.position
-          );
-          store.set(seekBarValueAtom, getSeekBarValue());
-          break;
-        }
-        case WebsocketDataTypes.VolumeChanged: {
-          queryClient.setQueryData(['volume'], () => message.volume);
-          queryClient.setQueryData(['isMuted'], () => message.muted);
-          store.set(volumeSliderValueAtom, message.volume);
-          break;
-        }
-        case WebsocketDataTypes.RepeatChanged: {
-          queryClient.setQueryData(['repeatMode'], () => message.repeat);
-          break;
-        }
-        case WebsocketDataTypes.ShuffleChanged: {
-          queryClient.setQueryData(['isShuffle'], () => message.shuffle);
-          break;
-        }
-      }
-    },
+    onMessage: async (event) => handleMessage(event.data),
     shouldReconnect: true,
     reconnectInterval: WEBSOCKET_RECONNECT_INTERVAL_MS,
   });
 
   useEffect(() => {
-    switch (ws.readyState) {
+    if (Platform.OS === 'web') return;
+    if (!shouldConnect) return;
+
+    let websocket: WebSocket | null = null;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+    let isActive = true;
+
+    const connect = () => {
+      if (!isActive) return;
+
+      setNativeReadyState(ReadyState.CONNECTING);
+
+      const options = accessToken
+        ? ({
+            headers: {
+              Authorization: getAuthorizationHeader(accessToken),
+            },
+          } as any)
+        : undefined;
+
+      websocket = new WebSocket(url, undefined, options);
+
+      websocket.onopen = () => {
+        if (!isActive) return;
+        setNativeReadyState(ReadyState.OPEN);
+      };
+
+      websocket.onmessage = (event) => {
+        void handleMessage(String(event.data));
+      };
+
+      websocket.onerror = () => {
+        if (!isActive) return;
+        store.set(isWebsocketErrorAtom, true);
+      };
+
+      websocket.onclose = () => {
+        if (!isActive) return;
+        setNativeReadyState(ReadyState.CLOSED);
+        reconnectTimeout = setTimeout(connect, WEBSOCKET_RECONNECT_INTERVAL_MS);
+      };
+    };
+
+    connect();
+
+    return () => {
+      isActive = false;
+      if (reconnectTimeout) clearTimeout(reconnectTimeout);
+      if (websocket) websocket.close();
+    };
+  }, [accessToken, handleMessage, shouldConnect, url]);
+
+  const readyState =
+    Platform.OS === 'web'
+      ? ws.readyState
+      : shouldConnect
+        ? nativeReadyState
+        : ReadyState.UNINSTANTIATED;
+
+  useEffect(() => {
+    switch (readyState) {
       case ReadyState.CONNECTING:
         store.set(isWebsocketConnectingAtom, true);
         break;
@@ -158,7 +217,13 @@ export const useRealtimeUpdates = (enabled: boolean) => {
       default:
         break;
     }
-  }, [ws.readyState]);
+  }, [readyState]);
 
-  return ws;
+  return Platform.OS === 'web'
+    ? ws
+    : {
+        sendMessage: () => {},
+        readyState,
+        getWebSocket: () => null,
+      };
 };

--- a/hooks/useRealtimeUpdates.ts
+++ b/hooks/useRealtimeUpdates.ts
@@ -18,15 +18,16 @@ import {
 } from '@/configs';
 import { WebsocketDataSchema, WebsocketDataTypes } from '@/schemas';
 import { getQueue } from '@/services';
+import {
+  getAuthorizationHeader,
+  shouldIgnoreSeekPositionUpdate,
+} from '@/utils';
 import { getSeekBarValue } from '@/utils/getSeekBarValue';
 
 import { useConnectionString } from './useConnectionString';
 
 const WEBSOCKET_RECONNECT_INTERVAL_MS = 5000;
 const QUEUE_REFETCH_DELAY_MS = 500;
-
-const getAuthorizationHeader = (accessToken: string) =>
-  accessToken.startsWith('Bearer ') ? accessToken : `Bearer ${accessToken}`;
 
 /**
  * Re-implementation of useQuery hooks from original polled REST API GET
@@ -46,15 +47,17 @@ export const useRealtimeUpdates = (enabled: boolean) => {
     const message: WebsocketDataSchema = JSON.parse(messageData);
     const seekInFlightUntil = store.get(seekInFlightUntilAtom);
     const pendingSeekSeconds = store.get(pendingSeekSecondsAtom);
-    const isSeekInFlight = seekInFlightUntil > Date.now();
-    const shouldIgnoreSeekPositionUpdate = (position: number) =>
-      isSeekInFlight &&
-      pendingSeekSeconds !== null &&
-      Math.abs(position - pendingSeekSeconds) > 1;
 
     switch (message.type) {
       case WebsocketDataTypes.PlayerInfo: {
-        if (shouldIgnoreSeekPositionUpdate(message.position)) break;
+        if (
+          shouldIgnoreSeekPositionUpdate({
+            position: message.position,
+            pendingSeekSeconds,
+            seekInFlightUntil,
+          })
+        )
+          break;
         queryClient.setQueryData(['nowPlaying'], () => message.song || null);
         queryClient.setQueryData(
           ['nowPlayingElapsedSeconds'],
@@ -94,7 +97,14 @@ export const useRealtimeUpdates = (enabled: boolean) => {
         break;
       }
       case WebsocketDataTypes.PlayerStateChanged: {
-        if (shouldIgnoreSeekPositionUpdate(message.position)) break;
+        if (
+          shouldIgnoreSeekPositionUpdate({
+            position: message.position,
+            pendingSeekSeconds,
+            seekInFlightUntil,
+          })
+        )
+          break;
         store.set(seekInFlightUntilAtom, 0);
         store.set(pendingSeekSecondsAtom, null);
         queryClient.setQueryData(['isPlaying'], () => message.isPlaying);
@@ -106,7 +116,14 @@ export const useRealtimeUpdates = (enabled: boolean) => {
         break;
       }
       case WebsocketDataTypes.PositionChanged: {
-        if (shouldIgnoreSeekPositionUpdate(message.position)) break;
+        if (
+          shouldIgnoreSeekPositionUpdate({
+            position: message.position,
+            pendingSeekSeconds,
+            seekInFlightUntil,
+          })
+        )
+          break;
         store.set(seekInFlightUntilAtom, 0);
         store.set(pendingSeekSecondsAtom, null);
         queryClient.setQueryData(

--- a/locales/en.json
+++ b/locales/en.json
@@ -58,9 +58,9 @@
     "title": "Settings",
     "connection": {
       "title": "Connection",
-      "ipAddress": "IP Address",
-      "invalidIpAddress": "Invalid IP address",
-      "port": "Port",
+      "ipAddress": "Hostname or IP Address",
+      "invalidIpAddress": "Enter a valid hostname or IPv4 address",
+      "port": "Port (optional)",
       "invalidPort": "Port must be a number",
       "invalidPortRange": "Port must be between 1 and 65535",
       "connectionProfile": "Connection Profile",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -58,9 +58,9 @@
     "title": "設定",
     "connection": {
       "title": "接続",
-      "ipAddress": "IPアドレス",
-      "invalidIpAddress": "無効なIPアドレス",
-      "port": "ポート",
+      "ipAddress": "ホスト名またはIPアドレス",
+      "invalidIpAddress": "有効なホスト名またはIPv4アドレスを入力してください",
+      "port": "ポート（任意）",
       "invalidPort": "ポートは数字である必要があります",
       "invalidPortRange": "ポートは1から65535の間である必要があります",
       "connectionProfile": "接続プロファイル",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web",
+    "web": "WEB_HOST=0.0.0.0 expo start --web --lan",
     "test": "jest --watchAll",
     "lint": "expo lint",
     "build:android": "expo prebuild --clean && expo run:android --variant release",

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,0 +1,2 @@
+export const getAuthorizationHeader = (accessToken: string) =>
+  accessToken.startsWith('Bearer ') ? accessToken : `Bearer ${accessToken}`;

--- a/utils/connectionUrl.ts
+++ b/utils/connectionUrl.ts
@@ -1,0 +1,79 @@
+type ConnectionProtocol = 'http' | 'https' | 'ws' | 'wss';
+type ConnectionProtocolFamily = 'http' | 'ws';
+const DEFAULT_CONNECTION_PORT = '26538';
+
+const IPV4_ADDRESS_REGEX =
+  /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+
+const isPrivateIpv4 = (host: string) => {
+  if (!IPV4_ADDRESS_REGEX.test(host)) return false;
+
+  const [firstSegment, secondSegment] = host
+    .split('.')
+    .map((segment) => Number(segment));
+
+  return (
+    firstSegment === 10 ||
+    firstSegment === 127 ||
+    firstSegment === 0 ||
+    (firstSegment === 169 && secondSegment === 254) ||
+    (firstSegment === 172 && secondSegment >= 16 && secondSegment <= 31) ||
+    (firstSegment === 192 && secondSegment === 168)
+  );
+};
+
+export const isLocalConnectionHost = (host: string) => {
+  const normalizedHost = host.trim().toLowerCase();
+
+  if (!normalizedHost) return true;
+
+  return (
+    normalizedHost === 'localhost' ||
+    normalizedHost.endsWith('.local') ||
+    !normalizedHost.includes('.') ||
+    isPrivateIpv4(normalizedHost)
+  );
+};
+
+export const getConnectionProtocol = (
+  host: string,
+  protocolFamily: ConnectionProtocolFamily = 'http'
+): ConnectionProtocol => {
+  const isLocalHost = isLocalConnectionHost(host);
+
+  if (protocolFamily === 'ws') return isLocalHost ? 'ws' : 'wss';
+
+  return isLocalHost ? 'http' : 'https';
+};
+
+const getConnectionPort = (host: string, port: string) => {
+  const normalizedPort = port.trim();
+
+  if (isLocalConnectionHost(host))
+    return normalizedPort || DEFAULT_CONNECTION_PORT;
+
+  if (
+    !normalizedPort ||
+    normalizedPort === DEFAULT_CONNECTION_PORT ||
+    normalizedPort === '443'
+  )
+    return '';
+
+  return normalizedPort;
+};
+
+export const getConnectionOrigin = ({
+  host,
+  port,
+  protocolFamily = 'http',
+}: {
+  host: string;
+  port: string;
+  protocolFamily?: ConnectionProtocolFamily;
+}) => {
+  const normalizedHost = host.trim() || '0.0.0.0';
+  const protocol = getConnectionProtocol(normalizedHost, protocolFamily);
+  const resolvedPort = getConnectionPort(normalizedHost, port);
+
+  return `${protocol}://${normalizedHost}${resolvedPort ? `:${resolvedPort}` : ''}`;
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './auth';
 export * from './connectionUrl';
 export * from './formatSearchContinuations';
 export * from './formatSearchResult';
@@ -5,3 +6,4 @@ export * from './formatSecondsToDuration';
 export * from './formatTextRuns';
 export * from './goBack';
 export * from './pollQueue';
+export * from './seek';

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './connectionUrl';
 export * from './formatSearchContinuations';
 export * from './formatSearchResult';
 export * from './formatSecondsToDuration';

--- a/utils/seek.ts
+++ b/utils/seek.ts
@@ -1,0 +1,24 @@
+const DEFAULT_SEEK_TOLERANCE_SECONDS = 1;
+
+export const isWithinSeekTolerance = (
+  currentSeconds: number,
+  nextSeconds: number,
+  toleranceSeconds = DEFAULT_SEEK_TOLERANCE_SECONDS
+) => Math.abs(currentSeconds - nextSeconds) <= toleranceSeconds;
+
+export const shouldIgnoreSeekPositionUpdate = ({
+  position,
+  pendingSeekSeconds,
+  seekInFlightUntil,
+  now = Date.now(),
+  toleranceSeconds = DEFAULT_SEEK_TOLERANCE_SECONDS,
+}: {
+  position: number;
+  pendingSeekSeconds: number | null;
+  seekInFlightUntil: number;
+  now?: number;
+  toleranceSeconds?: number;
+}) =>
+  seekInFlightUntil > now &&
+  pendingSeekSeconds !== null &&
+  !isWithinSeekTolerance(position, pendingSeekSeconds, toleranceSeconds);


### PR DESCRIPTION
## Summary

This PR improves remote connection support and smooths out a few rough edges when using the app with the legacy YouTube Music desktop API server. Solves #177

Main improvements:
- allow hostname-based connections instead of IPv4/`localhost` only
- make the port optional for public/HTTPS-style hosts
- improve legacy `AUTH_AT_FIRST` authorization handling
- keep the UI working even if realtime websocket auth/connect fails
- reduce seek bar jitter after local seeks
- add regression tests around the new connection/auth/seek helper logic

## Changes

### Connection handling
- expanded host validation to accept valid hostnames in addition to IPv4 addresses
- updated connection labels/error copy to reflect hostname support
- made the port optional in settings
- added connection URL/protocol inference:
  - local targets (`localhost`, `.local`, private IPv4, single-label hosts) use `http` / `ws`
  - public hostnames use `https` / `wss`
  - remote/default-like ports are omitted when appropriate
- updated the web script to bind on `0.0.0.0`

### Legacy desktop auth flow
- aligned the mobile client with the legacy desktop API server’s `AUTH_AT_FIRST` flow
- replaced the hardcoded auth client id with a stable per-install client id
- switched auth to a dedicated client with a longer timeout so desktop approval has time to complete
- fixed authorization header formatting to always use `Bearer <token>`
- deduplicated concurrent auth attempts so multiple `401`s do not trigger multiple desktop prompts

### Realtime + fallback behavior
- improved startup behavior so REST-backed UI data can still load even if the websocket connection fails
- stopped clearing cached queue/player state just because the realtime connection closed or errored
- added native websocket auth header support for bearer tokens on mobile

### Seek behavior
- added optimistic local seek state while a seek is in flight
- ignored stale realtime position updates during the short post-seek grace window
- cleared the temporary seek override once the server catches up or the grace window expires
- reduced the visible seek slider/time “snap back” effect after dragging

### Tests
- added unit coverage for:
  - connection host/protocol/origin inference
  - bearer authorization header formatting
  - seek tolerance / stale position filtering helpers

## Testing

- `yarn lint`
- `yarn test --watchAll=false --runInBand`
- manual validation against the legacy desktop API server:
  - hostname-based connection setup
  - `AUTH_AT_FIRST` approval flow
  - REST fallback when websocket is unavailable
  - seek bar behavior after local seeks
