### PR TITLE
fix(searchbar): trigger search on mobile soft keyboard enter/submit

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -2,7 +2,14 @@ import { useState } from 'react';
 
 import { useGlobalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { NativeSyntheticEvent, Platform, StyleSheet, TextInputKeyPressEventData, TextInputProps, View } from 'react-native';
+import {
+  NativeSyntheticEvent,
+  Platform,
+  StyleSheet,
+  TextInputKeyPressEventData,
+  TextInputProps,
+  View,
+} from 'react-native';
 import { IconButton, TextInput, useTheme } from 'react-native-paper';
 
 const styles = StyleSheet.create({
@@ -44,7 +51,9 @@ const Searchbar = ({ onSubmit, ...props }: SearchbarProps) => {
   const hasQuery = query.trim().length !== 0;
   const clearQuery = () => setQuery('');
 
-  const handleKeyPress = (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+  const handleKeyPress = (
+    e: NativeSyntheticEvent<TextInputKeyPressEventData>
+  ) => {
     if (e.nativeEvent.key === 'Enter') {
       onSubmit(query);
     }
@@ -75,7 +84,7 @@ const Searchbar = ({ onSubmit, ...props }: SearchbarProps) => {
         autoFocus={!q}
         value={query}
         onChangeText={setQuery}
-        onSubmitEditing={() => onSubmit(query)}
+        // onSubmitEditing={() => onSubmit(query)}
         onKeyPress={handleKeyPress}
         blurOnSubmit={query.trim().length !== 0}
         {...props}

--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useGlobalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { Platform, StyleSheet, TextInputProps, View } from 'react-native';
+import { NativeSyntheticEvent, Platform, StyleSheet, TextInputKeyPressEventData, TextInputProps, View } from 'react-native';
 import { IconButton, TextInput, useTheme } from 'react-native-paper';
 
 const styles = StyleSheet.create({
@@ -44,6 +44,12 @@ const Searchbar = ({ onSubmit, ...props }: SearchbarProps) => {
   const hasQuery = query.trim().length !== 0;
   const clearQuery = () => setQuery('');
 
+  const handleKeyPress = (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+    if (e.nativeEvent.key === 'Enter') {
+      onSubmit(query);
+    }
+  };
+
   return (
     <View
       style={[
@@ -63,13 +69,14 @@ const Searchbar = ({ onSubmit, ...props }: SearchbarProps) => {
           },
         ]}
         placeholder={t('searchPlaceholder')}
-        // cursorColor={theme.colors.primary}
         returnKeyType='search'
+        enterKeyHint='search'
         autoCapitalize='none'
         autoFocus={!q}
         value={query}
         onChangeText={setQuery}
         onSubmitEditing={() => onSubmit(query)}
+        onKeyPress={handleKeyPress}
         blurOnSubmit={query.trim().length !== 0}
         {...props}
       />


### PR DESCRIPTION
### Summary of Changes
This PR fixes an issue where pressing the "Search" / "Enter" action button on mobile on-screen keyboards (virtual keyboards) did not trigger the search functionality on the web version.

### Root Cause
In mobile web browsers, `onSubmitEditing` alone on a `TextInput` does not reliably capture the form submission event from virtual keypads unless explicitly handled or wrapped in a form/key press listener.

### Key Changes
* Added `onKeyPress` event handler in `Searchbar.tsx` to detect the `'Enter'` key press explicitly.
* Added `enterKeyHint="search"` to explicitly instruct mobile virtual keyboards to show the search action button.